### PR TITLE
Fix message center memory leak

### DIFF
--- a/FS25_FSG_Companion/scripts/coopSiloManager.lua
+++ b/FS25_FSG_Companion/scripts/coopSiloManager.lua
@@ -18,7 +18,11 @@ function CoopSiloManager.new(mission, i18n, modDirectory, modName)
 
   g_messageCenter:subscribe(MessageType.MINUTE_CHANGED, self.onMinuteChanged, self)
 
-	return self
+        return self
+end
+
+function CoopSiloManager:delete()
+  g_messageCenter:unsubscribe(MessageType.MINUTE_CHANGED, self.onMinuteChanged, self)
 end
 
 function CoopSiloManager:update(dt)

--- a/FS25_FSG_Companion/scripts/farmCleanUp.lua
+++ b/FS25_FSG_Companion/scripts/farmCleanUp.lua
@@ -19,7 +19,12 @@ function FarmCleanUp.new(mission, i18n, modDirectory, modName)
   g_messageCenter:subscribe(MessageType.MINUTE_CHANGED, self.onMinuteChanged, self)
   g_messageCenter:subscribe(MessageType.DAY_CHANGED, self.onDayChanged, self)
 
-	return self
+        return self
+end
+
+function FarmCleanUp:delete()
+  g_messageCenter:unsubscribe(MessageType.MINUTE_CHANGED, self.onMinuteChanged, self)
+  g_messageCenter:unsubscribe(MessageType.DAY_CHANGED, self.onDayChanged, self)
 end
 
 function FarmCleanUp:onMinuteChanged(currentMinute)

--- a/FS25_FSG_Companion/scripts/farmPlaceableTax.lua
+++ b/FS25_FSG_Companion/scripts/farmPlaceableTax.lua
@@ -17,7 +17,11 @@ function FarmPlaceableTax.new(mission, i18n, modDirectory, modName)
 
   g_messageCenter:subscribe(MessageType.DAY_CHANGED, self.onDayChanged, self)
 
-	return self
+        return self
+end
+
+function FarmPlaceableTax:delete()
+  g_messageCenter:unsubscribe(MessageType.DAY_CHANGED, self.onDayChanged, self)
 end
 
 function FarmPlaceableTax:onDayChanged(currentDay)

--- a/FS25_FSG_Companion/scripts/fieldStats.lua
+++ b/FS25_FSG_Companion/scripts/fieldStats.lua
@@ -21,7 +21,11 @@ function FieldStats.new(mission, i18n, modDirectory, modName)
 
   g_messageCenter:subscribe(MessageType.HOUR_CHANGED, self.onHourChanged, self)
 
-	return self
+        return self
+end
+
+function FieldStats:delete()
+  g_messageCenter:unsubscribe(MessageType.HOUR_CHANGED, self.onHourChanged, self)
 end
 
 

--- a/FS25_FSG_Companion/scripts/fillManager.lua
+++ b/FS25_FSG_Companion/scripts/fillManager.lua
@@ -20,7 +20,12 @@ function FillManager.new(mission, i18n, modDirectory, modName)
   g_messageCenter:subscribe(MessageType.FARM_CREATED, self.updateStorages, self)
   g_messageCenter:subscribe(MessageType.FARM_DELETED, self.updateStorages, self)
 
-	return self
+        return self
+end
+
+function FillManager:delete()
+  g_messageCenter:unsubscribe(MessageType.FARM_CREATED, self.updateStorages, self)
+  g_messageCenter:unsubscribe(MessageType.FARM_DELETED, self.updateStorages, self)
 end
 
 

--- a/FS25_FSG_Companion/scripts/main.lua
+++ b/FS25_FSG_Companion/scripts/main.lua
@@ -192,6 +192,11 @@ local function unload()
 
   -- Run shutdown stuffs for the mod
   FieldStats:delete()
+  FarmCleanUp:delete()
+  FillManager:delete()
+  FarmPlaceableTax:delete()
+  CoopSiloManager:delete()
+  WeatherForecastStats:delete()
 
   removeModEventListener(modEnvironmentChat)
   if modEnvironmentChat ~= nil then

--- a/FS25_FSG_Companion/scripts/weatherForecastStats.lua
+++ b/FS25_FSG_Companion/scripts/weatherForecastStats.lua
@@ -15,7 +15,11 @@ function WeatherForecastStats.new(mission, i18n, modDirectory, modName)
   
   g_messageCenter:subscribe(MessageType.HOUR_CHANGED, self.onHourChanged, self)
 
-	return self
+        return self
+end
+
+function WeatherForecastStats:delete()
+  g_messageCenter:unsubscribe(MessageType.HOUR_CHANGED, self.onHourChanged, self)
 end
 
 function WeatherForecastStats:onHourChanged(currentHour)


### PR DESCRIPTION
## Summary
- unsubscribe each manager from g_messageCenter on unload
- call the new `delete` methods from `main.lua`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6873aff4bb0c8332ac7ce3396aabc226