### PR TITLE
Optimize loops and action registration

### DIFF
--- a/FS25_FSG_Companion/scripts/remoteCmds.lua
+++ b/FS25_FSG_Companion/scripts/remoteCmds.lua
@@ -10,7 +10,7 @@ function RemoteCommands.new(mission, i18n, modDirectory, modName)
   self.i18n                   = i18n
   self.modDirectory           = modDirectory
   self.modName                = modName
-  self.setValueTimerFrequency = 120
+  self.setValueTimerFrequency = 600
   self.commandInboxDir        = getUserProfileAppPath()  .. "modSettings/FS25_FSG_Companion/commands/inbox/"
   self.commandOutboxDir       = getUserProfileAppPath()  .. "modSettings/FS25_FSG_Companion/commands/outbox/"
   self.files                  = {}


### PR DESCRIPTION
## Summary
- avoid re-registering FSG_MENU action each frame
- reload settings XML only if the file changed
- reduce remote command polling frequency
- cache coop silo placeables to reduce update scanning

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_68783f492ba083329b09f0933b3b026c