### PR TITLE
Fix menu binding

### DIFF
--- a/FS25_FSG_Companion/scripts/FSGSettings.lua
+++ b/FS25_FSG_Companion/scripts/FSGSettings.lua
@@ -95,16 +95,21 @@ function FSGSettings:loadMap(filename)
   -- g_gui:loadGui(FSGSettings.modDirectory .. "gui/FSGSettingsFarmTransactionsFrame.xml", "FSGSettingsFarmTransactionsFrame", FSGFarmTransactionsFrame, true)
   g_gui:loadGui(FSGSettings.modDirectory .. "gui/FSGSettingsGui.xml", "FSGSettingsGui", FSGSettings.gui)
 
+  -- Register the FSG menu action once the GUI files are loaded
+  self:updateActionEvents()
+
 end
 
 -- Register Player Interaction
 function FSGSettings:updateActionEvents()
-  if g_currentMission:getIsClient() == true then
+  if g_currentMission:getIsClient() == true and g_inputBinding ~= nil then
     if self.actionEventId == nil then
       local _, actionEventId = g_inputBinding:registerActionEvent('FSG_MENU', self, FSGSettings.actionAdditionalInfo_openGui, false, true, false, true)
-      g_inputBinding:setActionEventTextPriority(actionEventId, GS_PRIO_VERY_LOW)
-      g_inputBinding:setActionEventText(actionEventId, g_i18n:getText("FSG_MENU"))
-      self.actionEventId = actionEventId
+      if actionEventId ~= nil then
+        g_inputBinding:setActionEventTextPriority(actionEventId, GS_PRIO_VERY_LOW)
+        g_inputBinding:setActionEventText(actionEventId, g_i18n:getText("FSG_MENU"))
+        self.actionEventId = actionEventId
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary
- register action binding after gui loads
- guard FSG menu registration if `g_inputBinding` isn't ready

## Testing
- `lua` not available

------
https://chatgpt.com/codex/tasks/task_e_68784f4aa95c8332bed3d348efdfb0ee