### PR TITLE
Increase pallet spawn area forgiveness

### DIFF
--- a/FS25_FSG_Companion/scripts/farmCleanUp.lua
+++ b/FS25_FSG_Companion/scripts/farmCleanUp.lua
@@ -375,7 +375,8 @@ function FarmCleanUp:getSpawnAreas()
             for _, spawnPlace in pairs(palletSpawner.spawnPlaces) do
                 local centerX = spawnPlace.startX + (spawnPlace.width / 2)
                 local centerZ = spawnPlace.startZ + (spawnPlace.length / 2)
-                local radius = math.max(spawnPlace.width, spawnPlace.length) / 2
+                -- Expand radius slightly to give spawned pallets more space
+                local radius = math.max(spawnPlace.width, spawnPlace.length) / 2 + 1
                 table.insert(spawnAreas, {x = centerX, z = centerZ, radius = radius})
             end
         end


### PR DESCRIPTION
## Summary
- expand pallet spawn radius slightly so pallets near edges aren't cleaned up

## Testing
- `luac -p FS25_FSG_Companion/scripts/farmCleanUp.lua` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688ebf66a500833289c53688eaa3ede3