### PR TITLE
Limit coop object storage to current farm's objects

### DIFF
--- a/FS25_FSG_Companion/scripts/coopSiloManager.lua
+++ b/FS25_FSG_Companion/scripts/coopSiloManager.lua
@@ -458,33 +458,37 @@ function CoopSiloManager:setObjectInfos(superFunc, objectInfos, maxUnloadAmount)
   rcDebug("farmId")
   rcDebug(farmId)
 
-	self.objectInfos = objectInfos
 	self.maxUnloadAmount = maxUnloadAmount or self.maxUnloadAmount
 	local objectInfoTable = {}
+  local filteredObjectInfos = {}
 
 	for _, objectInfo in pairs(objectInfos) do
-    -- Remove ojbects that are not owned by current farm
-    -- rcDebug("objectInfo")
-    -- rcDebug(objectInfo)
+    local filteredObjects = {}
 
-    -- rcDebug("objectInfo.objects Table")
-    -- rcDebug(objectInfo.objects)
     for i = 1, #objectInfo.objects do
-      rcDebug("objectInfo.objects Single")
-      rcDebug(objectInfo.objects[i])
-      if (objectInfo.objects[i] ~= nil and objectInfo.objects[i].palletAttributes ~= nil and objectInfo.objects[i].palletAttributes.ownerFarmId ~= nil and objectInfo.objects[i].palletAttributes.ownerFarmId ~= farmId)
-      or (objectInfo.objects[i] ~= nil and objectInfo.objects[i].baleAttributes~= nil and objectInfo.objects[i].baleAttributes.ownerFarmId ~= nil and objectInfo.objects[i].baleAttributes.ownerFarmId ~= farmId)
-      or (objectInfo.objects[i] ~= nil and objectInfo.objects[i].palletAttributes ~= nil and objectInfo.objects[i].palletAttributes.farmId ~= nil and objectInfo.objects[i].palletAttributes.farmId ~= farmId)
-      or (objectInfo.objects[i] ~= nil and objectInfo.objects[i].baleAttributes~= nil and objectInfo.objects[i].baleAttributes.farmId ~= nil and objectInfo.objects[i].baleAttributes.farmId ~= farmId) then
-        table.remove(objectInfo.objects, i)
+      local object = objectInfo.objects[i]
+      if object ~= nil then
+        local objectFarmId = nil
+        if object.palletAttributes ~= nil then
+          objectFarmId = object.palletAttributes.ownerFarmId or object.palletAttributes.farmId
+        elseif object.baleAttributes ~= nil then
+          objectFarmId = object.baleAttributes.ownerFarmId or object.baleAttributes.farmId
+        end
+
+        if objectFarmId ~= nil and objectFarmId == farmId then
+          table.insert(filteredObjects, object)
+        end
       end
     end
 
-		if objectInfo.objects[1] ~= nil then
-			table.insert(objectInfoTable, objectInfo.objects[1]:getDialogText())
-		end
+    if #filteredObjects > 0 then
+      objectInfo.objects = filteredObjects
+      table.insert(filteredObjectInfos, objectInfo)
+      table.insert(objectInfoTable, objectInfo.objects[1]:getDialogText())
+    end
 	end
 
+  self.objectInfos = filteredObjectInfos
 	self.itemsElement:setTexts(objectInfoTable)
 	self.itemsElement:setState(1, true)
 


### PR DESCRIPTION
### Motivation
- The coop object storage dialog currently shows and allows retrieval of objects belonging to any farm, which can let players access other farms' pallets/bales; this change restricts the UI and unload logic to only objects owned by the current farm.

### Description
- Updated `CoopSiloManager:setObjectInfos` in `FS25_FSG_Companion/scripts/coopSiloManager.lua` to filter incoming `objectInfos` by owner farm id using `palletAttributes.ownerFarmId`/`farmId` and `baleAttributes.ownerFarmId`/`farmId`.
- Replaced in-place `table.remove` logic with a safe filter that builds `filteredObjects` and `filteredObjectInfos`, assigns `self.objectInfos` to the filtered list, and preserves `self.maxUnloadAmount`.
- The UI item list (`itemsElement`) is populated only from filtered objects so the dialog only displays entries owned by the current farm.
- The change avoids index-skipping bugs from removing items while iterating and ensures only owner-owned objects can be unloaded.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697eac901f688332947e6e23483cc190)